### PR TITLE
Record type event refactor

### DIFF
--- a/client/src/components/RecordTable.tsx
+++ b/client/src/components/RecordTable.tsx
@@ -3,12 +3,11 @@ import { useHistory } from "react-router-dom";
 
 import { Box, CardContent, Typography } from "@mui/material";
 
-import { recordList } from "../lib/recordList";
 import { tRecord } from "../types";
 
-export function RecordTable({ type, records }): JSX.Element {
+export function RecordTable({ type, eventList, records }): JSX.Element {
     const history = useHistory();
-    const filteredEventList = recordList[type].filter((ea: string) => records.find((rec: tRecord) => rec.event === ea));
+    const filteredEventList = eventList[type].filter((ea: string) => records.find((rec: tRecord) => rec.event === ea));
 
     function handleClickActive(target: Element): void {
         const encodedString = target.id.toLowerCase().replace(/ /g, "-");

--- a/client/src/components/__tests__/RecordTable.test.tsx
+++ b/client/src/components/__tests__/RecordTable.test.tsx
@@ -1,25 +1,25 @@
 import React from "react";
 import { render, cleanup, screen } from "@testing-library/react";
+
+import { recordList } from "../../lib/recordList";
 import { RecordTable } from "../RecordTable";
 
 afterEach(cleanup);
 
 describe("RecordTable", () => {
     const type = "strength";
-    const records =
-    [
+    const records = [
         { id: 456789, date: "2020-12-22", type: "strength", event: "Back Squat", score: 300 },
         { id: 456756, date: "2021-02-30", type: "strength", event: "Bench Press", score: 200 },
         { id: 190229, date: "2022-08-14", type: "strength", event: "Deadlift", score: 400 },
     ];
 
-
     it("renders RecordTable without crashing", () => {
-        render(<RecordTable type={type} records={records} />);
+        render(<RecordTable type={type} records={records} eventList={recordList} />);
     });
 
     it("renders the correct number of records", () => {
-        render(<RecordTable type={type} records={records} />);
+        render(<RecordTable type={type} records={records} eventList={recordList} />);
         const numberOfRows = screen.getAllByTestId("recordItem");
         expect(numberOfRows.length).toBe(3);
     });

--- a/client/src/services/fetchData.ts
+++ b/client/src/services/fetchData.ts
@@ -203,13 +203,12 @@ export async function deleteWorkout(workout_id: string): Promise<void> {
 /**************************************************** RECORDS ***************************************************/
 /****************************************************************************************************************/
 
-export async function fetchRecord(params: Record<string, any>, abortCont: { signal: any }): Promise<void> {
-    const record_id = params.recordId;
+export async function fetchRecord(recordId: string, abortCont: { signal: any }): Promise<void> {
     const token = localStorage.getItem("token");
     const accountId = localStorage.getItem("accountId");
     const signal = abortCont === null ? null : abortCont.signal;
 
-    const res = await fetch(`${BASE_URL}/${accountId}/records/${record_id}/`, {
+    const res = await fetch(`${BASE_URL}/${accountId}/records/${recordId}/`, {
         method: "GET",
         signal: signal,
         headers: {
@@ -303,6 +302,23 @@ export async function fetchEventRecords(params: Record<string, any>, abortCont: 
     const signal = abortCont === null ? null : abortCont.signal;
 
     const res = await fetch(`${BASE_URL}/${accountId}/records/event/${event}/`, {
+        method: "GET",
+        signal: signal,
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            authorization: `Token ${token}`,
+        },
+    });
+    if (!res.ok) throw new Error(`Server error - status ${res.status}`);
+    return await res.json();
+}
+
+export async function fetchRecordList(abortCont: { signal: any }): Promise<void> {
+    const token = localStorage.getItem("token");
+    const signal = abortCont === null ? null : abortCont.signal;
+
+    const res = await fetch(`${BASE_URL}/records/event-list/`, {
         method: "GET",
         signal: signal,
         headers: {

--- a/client/src/utils/__tests__/validateRecord.test.ts
+++ b/client/src/utils/__tests__/validateRecord.test.ts
@@ -1,68 +1,69 @@
 import { validateRecord } from "../index";
+import { recordList } from "../../lib/recordList";
 
 describe("validateRecord", () => {
     it("[1] Should return true given valid data", () => {
-        const result = validateRecord("2022-04-06", "strength", "Press", "155");
+        const result = validateRecord("2022-04-06", "strength", "Press", "155", recordList);
         expect(result).toBe(true);
     });
 
     it("[2] Should return false with a type that does not exist in recordList", () => {
-        const result = validateRecord("2022-04-06", "banana", "Press", "155");
+        const result = validateRecord("2022-04-06", "banana", "Press", "155", recordList);
         expect(result).toBe(false);
     });
 
     it("[3] Should return false with an event that does not exist in the recordList", () => {
-        const result = validateRecord("2022-04-06", "strength", "banana", "155");
+        const result = validateRecord("2022-04-06", "strength", "banana", "155", recordList);
         expect(result).toBe(false);
     });
 
     it("[4] Should return false with an empty score", () => {
-        const result = validateRecord("2022-04-06", "strength", "Press", "");
+        const result = validateRecord("2022-04-06", "strength", "Press", "", recordList);
         expect(result).toBe(false);
     });
 
     it("[5] Should return false with null date", () => {
-        const result = validateRecord(null, "strength", "Press", "155");
+        const result = validateRecord(null, "strength", "Press", "155", recordList);
         expect(result).toBe(false);
     });
 
     it("[6] Should return false with null type", () => {
-        const result = validateRecord("2022-04-06", null, "Press", "155");
+        const result = validateRecord("2022-04-06", null, "Press", "155", recordList);
         expect(result).toBe(false);
     });
 
     it("[7] Should return false with null event", () => {
-        const result = validateRecord("2022-04-06", "strength", null, "155");
+        const result = validateRecord("2022-04-06", "strength", null, "155", recordList);
         expect(result).toBe(false);
     });
 
     it("[8] Should return false with null score", () => {
-        const result = validateRecord("2022-04-06", "strength", "Press", null);
+        const result = validateRecord("2022-04-06", "strength", "Press", null, recordList);
         expect(result).toBe(false);
     });
 
     it("[9] Should return false with date: slashes instead of dashes", () => {
-        const result = validateRecord("2022/04/06", "strength", "Press", "155");
+        const result = validateRecord("2022/04/06", "strength", "Press", "155", recordList);
         expect(result).toBe(false);
     });
 
     it("[10] Should return false with date: single digits in month and day", () => {
-        const result = validateRecord("2022-4-6", "strength", "Press", "155");
+        const result = validateRecord("2022-4-6", "strength", "Press", "155", recordList);
         expect(result).toBe(false);
     });
 
     it("[11] Should return false with date: invalid month number", () => {
-        const result = validateRecord("2022-13-06", "strength", "Press", "155");
+        const result = validateRecord("2022-13-06", "strength", "Press", "155", recordList);
         expect(result).toBe(false);
     });
 
     it("[12] Should return false with date: invalid day number", () => {
-        const result = validateRecord("2022-05-45", "strength", "Press", "155");
+        const result = validateRecord("2022-05-45", "strength", "Press", "155", recordList);
         expect(result).toBe(false);
     });
 
     it("[13] Should return false with date: invalid year number", () => {
-        const result = validateRecord("202-05-15", "strength", "Press", "155");
+        const result = validateRecord("202-05-15", "strength", "Press", "155", recordList);
         expect(result).toBe(false);
     });
 });

--- a/client/src/utils/validateRecord.ts
+++ b/client/src/utils/validateRecord.ts
@@ -1,28 +1,35 @@
-import { recordList } from "../lib/recordList";
+import { recordListTypes } from "../types";
 
 /**
  * Utility function that validates a record, ensuring that fields are not empty and that
  * the date is properly formatted.
- * 
+ *
  * @param date date of the workout, ex: 2022-04-06
  * @param type an enum of the type of event
  * @param event an enum of events
  * @param score weight lifted, time, number of reps or distance
+ * @param eventList dictionary of record types and events
  * @return if the data is valid, return true, else return false
  */
-export function validateRecord(date: string, type: string, event: string, score: string): boolean {
+export function validateRecord(
+    date: string,
+    type: string,
+    event: string,
+    score: string,
+    eventList: recordListTypes,
+): boolean {
     if (date === "" || date === null || date === undefined) return false;
     if (type === "" || type === null || type === undefined) return false;
     if (event === "" || event === null || event === undefined) return false;
     if (score === "" || score === null || score === undefined) return false;
 
     // validate type
-    if (!Object.keys(recordList).includes(type)) return false;
+    if (!Object.keys(eventList).includes(type)) return false;
 
     // validate event
-    if (!recordList[type].includes(event)) return false;
+    if (!eventList[type].includes(event)) return false;
 
-    // validate date 
+    // validate date
     const dateArr = date.split("-");
     if (dateArr.length !== 3) return false;
     if (dateArr[0].length !== 4 || Number(dateArr[0]) % 1 !== 0) return false;

--- a/client/src/views/Dashboard.tsx
+++ b/client/src/views/Dashboard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 
 import { Box, Card, CardHeader, CardContent, CircularProgress, Grid, Typography } from "@mui/material";
 
-import { fetchYearData, fetchRecords, fetchYearlyCount } from "../services/fetchData";
+import { fetchYearData, fetchRecords, fetchYearlyCount, fetchRecordList } from "../services/fetchData";
 import { months } from "../lib/months";
 import { RecordTable } from "../components/RecordTable";
 import { ServerError } from "../components/ServerError";
@@ -35,7 +35,7 @@ export function Dashboard(): JSX.Element {
             </Typography>
             {error && <ServerError errorMessage={error} />}
             {isLoading && <CircularProgress />}
-            {!error && !isLoading && (
+            {!error && !isLoading && data && (
                 <Box sx={style.dashboardContainer}>
                     {/**************************************** MONTH SUMMARY **************************************/}
                     <Card elevation={3} sx={style.cardStyle}>
@@ -72,17 +72,29 @@ export function Dashboard(): JSX.Element {
                     {/**************************************** STRENGTH PRs ***************************************/}
                     <Card elevation={3} sx={style.cardStyle}>
                         <CardHeader title="Strength PRs" sx={style.header} />
-                        <RecordTable type={"strength"} records={records.filter((ea) => ea.type === "strength")} />
+                        <RecordTable
+                            type={"strength"}
+                            eventList={data.eventList}
+                            records={records.filter((ea) => ea.type === "strength")}
+                        />
                     </Card>
                     {/**************************************** ENDURANCE PRs **************************************/}
                     <Card elevation={3} sx={style.cardStyle}>
                         <CardHeader title="Endurance PRs" sx={style.header} />
-                        <RecordTable type={"endurance"} records={records.filter((ea) => ea.type === "endurance")} />
+                        <RecordTable
+                            type={"endurance"}
+                            eventList={data.eventList}
+                            records={records.filter((ea) => ea.type === "endurance")}
+                        />
                     </Card>
                     {/******************************************* WOD PRs *****************************************/}
                     <Card elevation={3} sx={style.cardStyle}>
                         <CardHeader title="WOD PRs" sx={style.header} />
-                        <RecordTable type={"wod"} records={records.filter((ea) => ea.type === "wod")} />
+                        <RecordTable
+                            type={"wod"}
+                            eventList={data.eventList}
+                            records={records.filter((ea) => ea.type === "wod")}
+                        />
                     </Card>
                 </Box>
             )}
@@ -110,8 +122,9 @@ function useFetchDashboardData(currentYear: string): Record<string, any> {
                 const recordData = await fetchRecords(abortCont);
                 const yearData = await fetchYearData(currentYear, abortCont);
                 const yearlyCountData = await fetchYearlyCount(abortCont);
+                const eventList = await fetchRecordList(abortCont);
 
-                setData({ recordData, yearData, yearlyCountData });
+                setData({ recordData, yearData, yearlyCountData, eventList });
                 setIsLoading(false);
             } catch (error) {
                 if (error.name === "AbortError") return;

--- a/client/src/views/__tests__/Record.test.tsx
+++ b/client/src/views/__tests__/Record.test.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
 import { server, rest } from "../../mockServer";
+import { recordList } from "../../lib/recordList";
 import { Record } from "../Record";
 
 afterEach(cleanup);
@@ -20,6 +22,12 @@ describe("Record view - new", () => {
         const today = new Date().toLocaleDateString("en-US").split("/");
         const todayFormatted = `${today[2]}-${today[0]?.padStart(2, "0")}-${today[1]?.padStart(2, "0")}`;
 
+        server.use(
+            rest.get("*/records/event-list/", (req, res, context) => {
+                return res(context.status(200), context.json(recordList));
+            }),
+        );
+
         render(<MockedNewRecord />);
         // check that todays date is automatically set in the date input
         const dateValue = await screen.findByDisplayValue(todayFormatted);
@@ -32,6 +40,12 @@ describe("Record view - new", () => {
         server.use(
             rest.post("*/1/records", (req, res, context) => {
                 return res(context.status(200), context.json({ ok: true }));
+            }),
+        );
+
+        server.use(
+            rest.get("*/records/event-list/", (req, res, context) => {
+                return res(context.status(200), context.json(recordList));
             }),
         );
 
@@ -74,6 +88,9 @@ describe("Record view - existing", () => {
         localStorage.setItem("accountId", "1");
 
         server.use(
+            rest.get("*/records/event-list/", (req, res, context) => {
+                return res(context.status(200), context.json(recordList));
+            }),
             rest.get("*/1/records/qwerty123456", (req, res, context) => {
                 return res(
                     context.status(200),
@@ -108,6 +125,9 @@ describe("Record view - existing", () => {
         localStorage.setItem("accountId", "1");
 
         server.use(
+            rest.get("*/records/event-list/", (req, res, context) => {
+                return res(context.status(200), context.json(recordList));
+            }),
             rest.get("*/1/records/qwerty123456", (req, res, context) => {
                 return res(
                     context.status(200),
@@ -150,6 +170,9 @@ describe("Record view - existing", () => {
         const updatedScore = "3:00";
 
         server.use(
+            rest.get("*/records/event-list/", (req, res, context) => {
+                return res(context.status(200), context.json(recordList));
+            }),
             rest.get("*/1/records/qwerty123456", (req, res, context) => {
                 return res(
                     context.status(200),

--- a/server/records/models.py
+++ b/server/records/models.py
@@ -5,6 +5,54 @@ from django.conf import settings
 
 
 class Record(models.Model):
+
+    RECORD_TYPE_EVENT_LIST = {
+        "strength": [
+            "Back Squat",
+            "Bench Press",
+            "Clean",
+            "Clean & Jerk",
+            "Deadlift",
+            "Dead Hang",
+            "Front Squat",
+            "Press",
+            "Push Press",
+            "Power Clean",
+            "Push Jerk",
+            "Snatch",
+            "Thruster",
+        ],
+        "endurance": [
+            "10 min Air Bike",
+            "30 min Air Bike",
+            "Bike Erg 30 min",
+            "Bike Erg 60 min",
+            "Bike Erg Marathon",
+            "Row 500m",
+            "Row 1,000m",
+            "Row 2,000m",
+            "Row 5,000m",
+            "Row 10,000m",
+            "Run 5km",
+            "Run 10km",
+        ],
+        "wod": [
+            "Angie",
+            "Cindy",
+            "Diane",
+            "DT",
+            "Fight Gone Badge",
+            "Filthy Fifty",
+            "Fran",
+            "Grace",
+            "Helen",
+            "Isabelle",
+            "Jackie",
+            "Linda",
+            "Murph",
+        ],
+    }
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True)
     date = models.DateField()

--- a/server/records/serializers.py
+++ b/server/records/serializers.py
@@ -6,3 +6,17 @@ class RecordSerializer(serializers.ModelSerializer):
     class Meta:
         fields = ("id", "author", "date", "type", "event", "score", "created_at", "updated_at")
         model = Record
+
+    def validate(self, data):
+        """
+        Confirm that the record type is valid and the event exists for this type
+        """
+        types = Record.RECORD_TYPE_EVENT_LIST.keys()
+        if data["type"] not in types:
+            raise serializers.ValidationError("Record type is not valid choice")
+
+        event_list = Record.RECORD_TYPE_EVENT_LIST[data["type"]]
+        if data["event"] not in event_list:
+            raise serializers.ValidationError("Not a valid event for this record type")
+
+        return data

--- a/server/records/urls.py
+++ b/server/records/urls.py
@@ -1,9 +1,15 @@
 from django.urls import path
-from .views import RecordList, RecordDetail, RecordSearch, EventRecordList
+from .views import RecordList, RecordDetail, RecordSearch, EventRecordList, get_all_event_choices
 
 urlpatterns = [
-    path("<int:author_id>/records/event/<str:event>/", EventRecordList.as_view()),
+    # Get, Update or Delete a single record
     path("<int:author_id>/records/<uuid:pk>/", RecordDetail.as_view()),
+    # Get all records that match the search query
     path("<int:author_id>/records/search/", RecordSearch.as_view()),
+    # Create new record and get the newest record for each event type for a user
     path("<int:author_id>/records/", RecordList.as_view(), name="records"),
+    # Get all records for a user and an event type
+    path("<int:author_id>/records/event/<str:event>/", EventRecordList.as_view()),
+    # Get the record type and event list as a dictionary
+    path("records/event-list/", get_all_event_choices),
 ]

--- a/server/records/utils.py
+++ b/server/records/utils.py
@@ -1,8 +1,8 @@
 
 def latest_record_for_event(queryset):
     """
-    Given a list of dictionaries with an even type, return
-    the latest object per event type
+    Given a list of dictionaries with an event type,
+    return the latest object per event type
     """
     filtered_list = []
     tempEventDict = {}


### PR DESCRIPTION
Originally, the record type and event dictionary lived on the front end which is not secure  nor considered best practice.

This PR moves this dictionary to the back end. The front end now needs to make an API call to get this dictionary to populate the form dropdown list. The back end can now use the dictionary to validate the data being saved or updated which makes things much more secure.

There is still front end validation happening before submitting the form, in additional to the back end validation after the form is submitted.